### PR TITLE
Allow user to choose smoothing iterations.

### DIFF
--- a/FreeSurfer/FNL_FreeInfantPipeline.sh
+++ b/FreeSurfer/FNL_FreeInfantPipeline.sh
@@ -182,17 +182,8 @@ if ${CrudeHistogramMatching:-true}; then
     # choose the number of iterations.
     surf_files=${SUBJECTS_DIR}/${SubjectID}/surf
     mri_files=${SUBJECTS_DIR}/${SubjectID}/mri
-    # Note: will need to make some temp files needed by mris_smooth, first.
-    mri_mask -T 5 ${surf_files}/brain.mgz ${surf_files}/brainmask.mgz ${surf_files}/brain.finalsurfs.mgz
-    mris_make_surfaces -aseg ${mri_files}/aseg.presurf -whiteonly -noaparc -mgz -T1 ${surf_files}/brain.finalsurfs ${SubjectID} lh
-    mris_make_surfaces -aseg ${mri_files}/aseg.presurf -whiteonly -noaparc -mgz -T1 ${surf_files}/brain.finalsurfs ${SubjectID} rh
-    # Make the r/l smoothwm files.
-    mris_smooth -n ${SmoothingIterations} -nw ${surf_files}/lh.white.preaparc ${surf_files}/lh.smoothwm
-    mris_smooth -n ${SmoothingIterations} -nw ${surf_files}/rh.white.preaparc ${surf_files}/rh.smoothwm
-    # Now that we have  r/l smoothwm, no longer need preaparc files. (The finalsurfs file
-    # is used by recon-all, so will let it clean it up.)
-    rm ${surf_files}/lh.white.preaparc ${surf_files}/rh.white.preaparc
-
+    mris_smooth -n ${SmoothingIterations} -nw ${surf_files}/lh.white ${surf_files}/lh.smoothwm
+    mris_smooth -n ${SmoothingIterations} -nw ${surf_files}/rh.white ${surf_files}/rh.smoothwm
     recon-all -subjid ${SubjectID} -inflate2 -sphere -surfreg -jacobian_white -avgcurv -cortparc
     cp "${SUBJECTS_DIR}"/"$SubjectID"/mri/aseg.mgz "${SUBJECTS_DIR}"/"$SubjectID"/mri/wmparc.mgz
     echo "END: recon-all-to-pial for T1w"

--- a/FreeSurfer/FNL_FreeInfantPipeline.sh
+++ b/FreeSurfer/FNL_FreeInfantPipeline.sh
@@ -177,10 +177,22 @@ if ${CrudeHistogramMatching:-true}; then
     cp ${SubjectID}N/mri/brain.finalsurfs.mgz ${SubjectID}/mri/brain.AN.mgz
     mris_make_surfaces ${MAXTHICKNESS} -whiteonly -noaparc -mgz -T1 brain.AN ${SubjectID} lh
     mris_make_surfaces ${MAXTHICKNESS} -whiteonly -noaparc -mgz -T1 brain.AN ${SubjectID} rh
-    # Do our own smoothing before the next recon-all so that we can choose the number of iterations.
+
+    # Do our own smoothing before (rather than within) the next recon-all so that we can
+    # choose the number of iterations.
     surf_files=${SUBJECTS_DIR}/${SubjectID}/surf
+    mri_files=${SUBJECTS_DIR}/${SubjectID}/mri
+    # Note: will need to make some temp files needed by mris_smooth, first.
+    mri_mask -T 5 ${surf_files}/brain.mgz ${surf_files}/brainmask.mgz ${surf_files}/brain.finalsurfs.mgz
+    mris_make_surfaces -aseg ${mri_files}/aseg.presurf -whiteonly -noaparc -mgz -T1 ${surf_files}/brain.finalsurfs ${SubjectID} lh
+    mris_make_surfaces -aseg ${mri_files}/aseg.presurf -whiteonly -noaparc -mgz -T1 ${surf_files}/brain.finalsurfs ${SubjectID} rh
+    # Make the r/l smoothwm files.
     mris_smooth -n ${SmoothingIterations} -nw ${surf_files}/lh.white.preaparc ${surf_files}/lh.smoothwm
     mris_smooth -n ${SmoothingIterations} -nw ${surf_files}/rh.white.preaparc ${surf_files}/rh.smoothwm
+    # Now that we have  r/l smoothwm, no longer need preaparc files. (The finalsurfs file
+    # is used by recon-all, so will let it clean it up.)
+    rm ${surf_files}/lh.white.preaparc ${surf_files}/rh.white.preaparc
+
     recon-all -subjid ${SubjectID} -inflate2 -sphere -surfreg -jacobian_white -avgcurv -cortparc
     cp "${SUBJECTS_DIR}"/"$SubjectID"/mri/aseg.mgz "${SUBJECTS_DIR}"/"$SubjectID"/mri/wmparc.mgz
     echo "END: recon-all-to-pial for T1w"

--- a/FreeSurfer/FNL_FreeInfantPipeline.sh
+++ b/FreeSurfer/FNL_FreeInfantPipeline.sh
@@ -179,8 +179,8 @@ if ${CrudeHistogramMatching:-true}; then
     mris_make_surfaces ${MAXTHICKNESS} -whiteonly -noaparc -mgz -T1 brain.AN ${SubjectID} rh
     # Do our own smoothing before the next recon-all so that we can choose the number of iterations.
     surf_files=${SUBJECTS_DIR}/${SubjectID}/surf
-    mris_smooth -n ${SmoothingIterations} ${surf_files}/lh.orig.nofix ${surf_files}/lh.smoothwm.nofix
-    mris_smooth -n ${SmoothingIterations} ${surf_files}/rh.orig.nofix ${surf_files}/rh.smoothwm.nofix
+    mris_smooth -n ${SmoothingIterations} ${surf_files}/lh.white.preaparc ${surf_files}/lh.smoothwm
+    mris_smooth -n ${SmoothingIterations} ${surf_files}/rh.white.preaparc ${surf_files}/rh.smoothwm
     recon-all -subjid ${SubjectID} -inflate2 -sphere -surfreg -jacobian_white -avgcurv -cortparc
     cp "${SUBJECTS_DIR}"/"$SubjectID"/mri/aseg.mgz "${SUBJECTS_DIR}"/"$SubjectID"/mri/wmparc.mgz
     echo "END: recon-all-to-pial for T1w"

--- a/FreeSurfer/FNL_FreeInfantPipeline.sh
+++ b/FreeSurfer/FNL_FreeInfantPipeline.sh
@@ -178,8 +178,9 @@ if ${CrudeHistogramMatching:-true}; then
     mris_make_surfaces ${MAXTHICKNESS} -whiteonly -noaparc -mgz -T1 brain.AN ${SubjectID} lh
     mris_make_surfaces ${MAXTHICKNESS} -whiteonly -noaparc -mgz -T1 brain.AN ${SubjectID} rh
     # Do our own smoothing before the next recon-all so that we can choose the number of iterations.
-    mris_smooth -n ${SmoothingIterations} lh.orig.nofix lh.smoothwm.nofix
-    mris_smooth -n ${SmoothingIterations} rh.orig.nofix rh.smoothwm.nofix
+    surf_files=${SUBJECTS_DIR}/${SubjectID}/surf
+    mris_smooth -n ${SmoothingIterations} ${surf_files}/lh.orig.nofix ${surf_files}/lh.smoothwm.nofix
+    mris_smooth -n ${SmoothingIterations} ${surf_files}/rh.orig.nofix ${surf_files}/rh.smoothwm.nofix
     recon-all -subjid ${SubjectID} -inflate2 -sphere -surfreg -jacobian_white -avgcurv -cortparc
     cp "${SUBJECTS_DIR}"/"$SubjectID"/mri/aseg.mgz "${SUBJECTS_DIR}"/"$SubjectID"/mri/wmparc.mgz
     echo "END: recon-all-to-pial for T1w"

--- a/FreeSurfer/FNL_FreeInfantPipeline.sh
+++ b/FreeSurfer/FNL_FreeInfantPipeline.sh
@@ -25,7 +25,7 @@ GCA=`opts_GetOpt1 "--gca" $@`
 useT2=`opts_GetOpt1 "--useT2" $@`
 MaxThickness=`opts_GetOpt1 "--maxThickness" $@` # Max threshold for thickness measurements (default = 5mm)
 NormMethod=`opts_GetOpt1 "--normalizationMethod" $@`
-SmoothingIterations=`opts_GetOpt1 "--smoothingIterations" $@
+SmoothingIterations=`opts_GetOpt1 "--smoothingIterations" $@`
 
 T1wImageFile=`remove_ext $T1wImage`
 T1wImageBrainFile=`remove_ext $T1wImageBrain`

--- a/FreeSurfer/FNL_FreeInfantPipeline.sh
+++ b/FreeSurfer/FNL_FreeInfantPipeline.sh
@@ -179,8 +179,8 @@ if ${CrudeHistogramMatching:-true}; then
     mris_make_surfaces ${MAXTHICKNESS} -whiteonly -noaparc -mgz -T1 brain.AN ${SubjectID} rh
     # Do our own smoothing before the next recon-all so that we can choose the number of iterations.
     surf_files=${SUBJECTS_DIR}/${SubjectID}/surf
-    mris_smooth -n ${SmoothingIterations} ${surf_files}/lh.white.preaparc ${surf_files}/lh.smoothwm
-    mris_smooth -n ${SmoothingIterations} ${surf_files}/rh.white.preaparc ${surf_files}/rh.smoothwm
+    mris_smooth -n ${SmoothingIterations} -nw ${surf_files}/lh.white.preaparc ${surf_files}/lh.smoothwm
+    mris_smooth -n ${SmoothingIterations} -nw ${surf_files}/rh.white.preaparc ${surf_files}/rh.smoothwm
     recon-all -subjid ${SubjectID} -inflate2 -sphere -surfreg -jacobian_white -avgcurv -cortparc
     cp "${SUBJECTS_DIR}"/"$SubjectID"/mri/aseg.mgz "${SUBJECTS_DIR}"/"$SubjectID"/mri/wmparc.mgz
     echo "END: recon-all-to-pial for T1w"

--- a/FreeSurfer/FNL_FreeInfantPipeline.sh
+++ b/FreeSurfer/FNL_FreeInfantPipeline.sh
@@ -25,7 +25,7 @@ GCA=`opts_GetOpt1 "--gca" $@`
 useT2=`opts_GetOpt1 "--useT2" $@`
 MaxThickness=`opts_GetOpt1 "--maxThickness" $@` # Max threshold for thickness measurements (default = 5mm)
 NormMethod=`opts_GetOpt1 "--normalizationMethod" $@`
-SmoothIterations=`opts_GetOpt1 "--smoothiterations" $@
+SmoothingIterations=`opts_GetOpt1 "--smoothingIterations" $@
 
 T1wImageFile=`remove_ext $T1wImage`
 T1wImageBrainFile=`remove_ext $T1wImageBrain`
@@ -46,8 +46,8 @@ if [ -z "${MaxThickness}" ] ; then
 fi
 MAXTHICKNESS="-max ${MaxThickness}"
 
-if [ -z "${SmoothIterations}" ] ; then
-    SmoothIterations=10      # mris_smooth default is 10 iterations
+if [ -z "${SmoothingIterations}" ] ; then
+    SmoothingIterations=10      # mris_smooth default is 10 iterations
 fi
 
 ######## FNL CODE #######
@@ -176,8 +176,8 @@ if ${CrudeHistogramMatching:-true}; then
     mris_make_surfaces ${MAXTHICKNESS} -whiteonly -noaparc -mgz -T1 brain.AN ${SubjectID} lh
     mris_make_surfaces ${MAXTHICKNESS} -whiteonly -noaparc -mgz -T1 brain.AN ${SubjectID} rh
     # Do our own smoothing before the next recon-all so that we can choose the number of iterations.
-    mris_smooth -n ${SmoothIterations} lh.orig.nofix lh.smoothwm.nofix
-    mris_smooth -n ${SmoothIterations} rh.orig.nofix rh.smoothwm.nofix
+    mris_smooth -n ${SmoothingIterations} lh.orig.nofix lh.smoothwm.nofix
+    mris_smooth -n ${SmoothingIterations} rh.orig.nofix rh.smoothwm.nofix
     recon-all -subjid ${SubjectID} -inflate2 -sphere -surfreg -jacobian_white -avgcurv -cortparc
     cp "${SUBJECTS_DIR}"/"$SubjectID"/mri/aseg.mgz "${SUBJECTS_DIR}"/"$SubjectID"/mri/wmparc.mgz
     echo "END: recon-all-to-pial for T1w"

--- a/FreeSurfer/FNL_FreeInfantPipeline.sh
+++ b/FreeSurfer/FNL_FreeInfantPipeline.sh
@@ -47,7 +47,9 @@ fi
 MAXTHICKNESS="-max ${MaxThickness}"
 
 if [ -z "${SmoothingIterations}" ] ; then
-    SmoothingIterations=10      # mris_smooth default is 10 iterations
+    # mris_smooth default is 10 iterations
+    log_Msg "No smoothing iterations were provided. Using default of 10."
+    SmoothingIterations=10
 fi
 
 ######## FNL CODE #######


### PR DESCRIPTION
Broke out smoothing from the mris_make_surfaces call so that we could specify the number of iterations to use. (-smooth2 option automatically does 3). Defaulting to 10 for now, but user can choose, so we can determine some "optimal" number for most subjects, and then change it if some need more/less.