### PR TITLE
Fix: name of aseg file was hardcoded

### DIFF
--- a/FreeSurfer/FNL_FreeInfantPipeline.sh
+++ b/FreeSurfer/FNL_FreeInfantPipeline.sh
@@ -83,7 +83,7 @@ Mean=`fslstats $T1wImageBrain -M`
 if [[ "${NormMethod^^}" == "NONE" ]] ; then
     echo Skipping hyper-normalization step per request.
 else
-    ${HCPPIPEDIR_FS}/hypernormalize.sh ${SUBJECTS_DIR} ${NormMethod}
+    ${HCPPIPEDIR_FS}/hypernormalize.sh ${SUBJECTS_DIR} ${Aseg} ${NormMethod}
     T1wNImage=${SUBJECTS_DIR}/T1wN_acpc.nii.gz
     T1wNImageBrain=${SUBJECTS_DIR}/T1wN_acpc_brain.nii.gz
     echo T1wNImage=$T1wNImage

--- a/FreeSurfer/scripts/hypernormalize.sh
+++ b/FreeSurfer/scripts/hypernormalize.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # args
-if [ $# -lt 1 ]; then
-    echo -e "Usage: `basename $0` <SUBJECT T1W DIRECTORY> [METHOD]"
+if [ $# -lt 2 ]; then
+    echo -e "Usage: `basename $0` <SUBJECT T1W DIRECTORY> <ASEG> [METHOD]"
     exit 1
 fi
 
@@ -9,7 +9,8 @@ SOURCE_DIR=$(readlink -f ${BASH_SOURCE%/*})
 echo SOURCE_DIR=${SOURCE_DIR}
 
 subjectdir=$1
-NormMethod=$2
+aseg=$2
+NormMethod=$3
 if [ -z  "${NormMethod}" ] ; then
     # Default is to use the adult grey matter intensity profile.
     NormMethod="ADULT_GM_IP"
@@ -17,7 +18,7 @@ fi
 
 cd ${subjectdir}
 
-${SOURCE_DIR}/make_WMGMCSF_masks.sh T1w_acpc_dc_restore.nii.gz aseg_acpc.nii.gz
+${SOURCE_DIR}/make_WMGMCSF_masks.sh T1w_acpc_dc_restore.nii.gz ${aseg}
 
 if [[ "${NormMethod^^}" == "ROI_IPS" ]] ; then
     # Call the old script that changes each ROI's intensity profile and puts them back together.

--- a/PreFreeSurfer/PreFreeSurferPipeline.sh
+++ b/PreFreeSurfer/PreFreeSurferPipeline.sh
@@ -643,11 +643,13 @@ if [ -n "${T1BrainMask}" ] ; then
     # the T1w mask to make the T2w mask.
 
     # Copy the user-supplied mask to ${T1wFolder}/${T1wImage}_brain_mask.
+    # The brain mask we are using here is already acpc aligned - KS 20200601.
     imcp ${T1BrainMask} ${T1wFolder}/${T1wImage}_brain_mask
+    imcp ${T1BrainMask} ${T1wFolder}/${T1wImage}_acpc_brain_mask
 
     # The T1w head was ACPC aligned in the loop above. Use the resulting
     # acpc.mat to align the mask.
-    ${FSLDIR}/bin/applywarp --rel --interp=nn -i ${T1wFolder}/${T1wImage}_brain_mask -r ${T1wTemplateBrain} --premat=${T1wFolder}/xfms/acpc.mat -o ${T1wFolder}/${T1wImage}_acpc_brain_mask
+    #${FSLDIR}/bin/applywarp --rel --interp=nn -i ${T1wFolder}/${T1wImage}_brain_mask -r ${T1wTemplateBrain} --premat=${T1wFolder}/xfms/acpc.mat -o ${T1wFolder}/${T1wImage}_acpc_brain_mask
 
     # Use the ACPC aligned T1w brain mask to extract the T1w brain.
     ${FSLDIR}/bin/fslmaths ${T1wFolder}/${T1wImage}_acpc -mas ${T1wFolder}/${T1wImage}_acpc_brain_mask ${T1wFolder}/${T1wImage}_acpc_brain


### PR DESCRIPTION
Found a place in a script that was using the hardcoded name of the aseg file generated in PreFreeSurfer. The trouble is, when we pass in a different aseg, we need to use the one supplied throughout processing.